### PR TITLE
Make Faraday version less restrictive

### DIFF
--- a/lib/rubyviber/version.rb
+++ b/lib/rubyviber/version.rb
@@ -1,3 +1,3 @@
 module Rubyviber
-  VERSION = "0.2.2"
+  VERSION = "0.3.0"
 end

--- a/rubyviber.gemspec
+++ b/rubyviber.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.10"
-  spec.add_dependency "faraday_middleware", "~> 0.10"
+  spec.add_dependency "faraday", [">= 0.10", "< 2.0"]
+  spec.add_dependency "faraday_middleware", [">= 0.10", "< 2.0"]
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
- Anything from 0.10 to < 2
- Tested 1.0.1 manually, on an application. `send_message` works.
- Based on https://github.com/lostisland/faraday/blob/master/CHANGELOG.md, no breaking changes from 0.x to 1.x
- Update bundler (development only)